### PR TITLE
Non latin names

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,36 @@ Address.prototype.name = function () {
     return name;
 }
 
+exports.isAllLower = function (string) {
+    return string === string.toLowerCase();
+}
+
+exports.isAllUpper = function (string) {
+    return string === string.toUpperCase();
+}
+
+exports.nameCase = function (string) {
+
+    // Set the case of the name to first char upper rest lower
+    return string
+        .toLowerCase()  // Upcase first letter on name
+        .replace(/\b(\w+)/g, function (_, d1) {
+            return d1.charAt(0).toUpperCase() + d1.slice(1);
+        })
+        .replace(/\bMc(\w)/gi, function (_, d1) {
+            // Scottish names such as 'McLeod'
+            return 'Mc' + d1.toUpperCase();
+        })
+        .replace(/\bo'(\w)/gi, function (_, d1) {
+            // Irish names such as 'O'Malley, O'Reilly'
+            return 'O\'' + d1.toUpperCase();
+        })
+        .replace(/\b(x*(ix)?v*(iv)?i*)\b/ig, function (_, d1) {
+            // Roman numerals, eg 'Level III Support'
+            return d1.toUpperCase();
+        });
+}
+
 // given a comment, attempt to extract a person's name
 function _extract_name (name) {
     // Using encodings, too hard. See Mail::Message::Field::Full.
@@ -253,14 +283,9 @@ function _extract_name (name) {
 
     // Change casing only when the name contains only upper or only
     // lower cased characters.
-    if ( ! (/[A-Z]/.test(name) && /[a-z]/.test(name)) ) {
+    if ( exports.isAllUpper(name) || exports.isAllLower(name) ) {
         // console.log("Changing case of: " + name);
-        name = name.toLowerCase();
-        // Set the case of the name to first char upper rest lower
-        name = name.replace(/\b(\w+)/g, function (_, d1) { return d1.charAt(0).toUpperCase() + d1.slice(1) })  // Upcase first letter on name
-                    .replace(/\bMc(\w)/gi, function (_, d1) { return 'Mc' + d1.toUpperCase() }) // Scottish names such as 'McLeod'
-                    .replace(/\bo'(\w)/gi, function (_, d1) { return 'O\'' + d1.toUpperCase() }) // Irish names such as 'O'Malley, O'Reilly'
-                    .replace(/\b(x*(ix)?v*(iv)?i*)\b/ig, function (_, d1) { return d1.toUpperCase() }) // Roman numerals, eg 'Level III Support'
+        name = exports.nameCase(name);
         // console.log("Now: " + name);
     }
 

--- a/index.js
+++ b/index.js
@@ -241,10 +241,10 @@ exports.isAllUpper = function (string) {
 
 exports.nameCase = function (string) {
 
-    // Set the case of the name to first char upper rest lower
     return string
-        .toLowerCase()  // Upcase first letter on name
+        .toLowerCase()
         .replace(/\b(\w+)/g, function (_, d1) {
+            // Set the case of the name to first char upper rest lower
             return d1.charAt(0).toUpperCase() + d1.slice(1);
         })
         .replace(/\bMc(\w)/gi, function (_, d1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2822",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "RFC 2822 (Header) email address parser",
   "main": "index.js",
   "homepage": "https://github.com/haraka/node-address-rfc2822",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,4 +1,4 @@
-var parse = require("../index").parse;
+var parse = require('../index').parse;
 
 function _check(test, line, details) {
     test.expect(Object.keys(details).length);
@@ -29,4 +29,3 @@ tests.forEach(function (test) {
         _check(t, test[0], details);
     }
 })
-

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -173,3 +173,7 @@ outlook@example.com
 "Foo; Bar" <both@example.com>, Baz <baz@example.com>
 "Foo; Bar" <both@example.com>
 Foo; Bar
+
+"Имя Фамилия" <name@gmail.com>
+"Имя Фамилия" <name@gmail.com>
+Имя Фамилия

--- a/test/functions.js
+++ b/test/functions.js
@@ -1,0 +1,45 @@
+var address = require('../index');
+
+exports.isAllLower = {
+    'lower latin string' : function (test) {
+        test.expect(1);
+        test.equal(true, address.isAllLower('abcdefg'));
+        test.done();
+    },
+}
+
+exports.isAllUpper = {
+    'upper latin string' : function (test) {
+        test.expect(1);
+        test.equal(true, address.isAllUpper('ABCDEFG'));
+        test.done();
+    }
+}
+
+exports.nameCase = {
+    'john doe -> John Doe' : function (test) {
+        test.expect(1);
+        test.equal('John Doe', address.nameCase('john doe'));
+        test.done();
+    },
+    'JANE SMITH -> Jane Smith' : function (test) {
+        test.expect(1);
+        test.equal('Jane Smith', address.nameCase('JANE SMITH'));
+        test.done();
+    },
+    'marty mcleod -> Marty McLeod': function (test) {
+        test.expect(1);
+        test.equal('Marty McLeod', address.nameCase('marty mcleod'));
+        test.done();
+    },
+    'martin o\'mally -> Martin O\'Malley': function (test) {
+        test.expect(1);
+        test.equal("Martin O'Malley", address.nameCase("martin o'malley"));
+        test.done();
+    },
+    'level iii support -> Level III Support': function (test) {
+        test.expect(1);
+        test.equal("Level III Support", address.nameCase("level iii support"));
+        test.done();
+    }
+}


### PR DESCRIPTION
* instead of regex A-Z (upper) and a-z (lower), use native JS toLowerCase() and toUpperCase()
* refactored nameCase
* added test for russian name (example from #8)
* added tests for nameCase(), isAllLower(), and isAllUpper()

fixes #8 
closes #9 