### PR TITLE
Allow comma in display name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,9 @@
 
+## 2.1.0 - 2021-02-26
+
+- make parse accept an options object as second argument
+- allow , character in display name, off by default #52
+
 ## 2.0.6 - 2020-11-17
 
 - replace travis/appveyor CI tests with Github Actions

--- a/index.js
+++ b/index.js
@@ -2,10 +2,19 @@
 
 const ea_lib = require('email-addresses');
 
-exports.parse = function parse (line, startAt = null, { allowCommaInDisplayName = false } = {}) {
+exports.parse = function parse (line, opts = null) {
     if (!line) throw new Error('Nothing to parse');
 
     line = line.trim();
+
+    const defaultOpts = {
+        startAt: null,
+        allowCommaInDisplayName: false,
+    }
+
+    const { startAt, allowCommaInDisplayName} = typeof opts === 'object'
+        ? Object.assign({}, defaultOpts, opts)
+        : Object.assign({}, defaultOpts, { startAt: opts })
 
     const addr = ea_lib({
         input: line,

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const ea_lib = require('email-addresses');
 
-exports.parse = function parse (line, startAt) {
+exports.parse = function parse (line, startAt = null, { allowCommaInDisplayName = false } = {}) {
     if (!line) throw new Error('Nothing to parse');
 
     line = line.trim();
@@ -16,7 +16,7 @@ exports.parse = function parse (line, startAt) {
         rejectTLD: false, // domains require a "."
         startAt: startAt || null,
         atInDisplayName: true, // allow at in display name
-        commaInDisplayName: true // allow comma in display name
+        commaInDisplayName: allowCommaInDisplayName,
     });
 
     if (!addr) throw new Error('No results');

--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ exports.parse = function parse (line, opts = null) {
 
     const defaultOpts = {
         startAt: null,
+        allowAtInDisplayName: true,
         allowCommaInDisplayName: false,
     }
 
-    const { startAt, allowCommaInDisplayName} = typeof opts === 'object'
+    const { startAt, allowAtInDisplayName, allowCommaInDisplayName } = typeof opts === 'object'
         ? Object.assign({}, defaultOpts, opts)
         : Object.assign({}, defaultOpts, { startAt: opts })
 
@@ -24,7 +25,7 @@ exports.parse = function parse (line, opts = null) {
         strict: false, // turn off obs- features in the rfc
         rejectTLD: false, // domains require a "."
         startAt: startAt || null,
-        atInDisplayName: true, // allow at in display name
+        atInDisplayName: allowAtInDisplayName,
         commaInDisplayName: allowCommaInDisplayName,
     });
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ exports.parse = function parse (line, startAt) {
         strict: false, // turn off obs- features in the rfc
         rejectTLD: false, // domains require a "."
         startAt: startAt || null,
-        atInDisplayName: true // allow at in display name
+        atInDisplayName: true, // allow at in display name
+        commaInDisplayName: true // allow comma in display name
     });
 
     if (!addr) throw new Error('No results');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2822",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "RFC 2822 & 5322 (Header) email address parser",
   "main": "index.js",
   "homepage": "https://github.com/haraka/node-address-rfc2822",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "email-addresses": "^3.1.0"
+    "email-addresses": "^4.0.0"
   }
 }

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -1,7 +1,3 @@
-Foo, Bar <foo@example.com>
-"Foo, Bar" <foo@example.com>
-Bar Foo
-
 foo@example <foo@example.com>
 "foo@example" <foo@example.com>
 Foo@Example

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -1,3 +1,7 @@
+Foo, Bar <foo@example.com>
+"Foo, Bar" <foo@example.com>
+Bar Foo
+
 foo@example <foo@example.com>
 "foo@example" <foo@example.com>
 Foo@Example

--- a/test/functions.js
+++ b/test/functions.js
@@ -91,3 +91,27 @@ describe('parseReplyTo', function () {
         done();
     })
 })
+
+describe('parse with options', function () {
+    it('should not allow parsing display name with comma by default', function (done) {
+        try {
+            const r = address.parse('Foo, Bar <foo@example.com>');
+        }
+        catch (e) {
+            assert.equal(e.message, 'No results');
+        }
+        done();
+    })
+
+    it('should allow parsing display name with comma', function (done) {
+        try {
+            const [r] = address.parse('Foo, Bar <foo@example.com>', null, { allowCommaInDisplayName: true });
+            assert.equal('foo@example.com', r.address);
+            assert.equal('Foo, Bar', r.phrase);
+        }
+        catch (e) {
+            console.error(e);
+        }
+        done();
+    })
+})

--- a/test/functions.js
+++ b/test/functions.js
@@ -105,7 +105,7 @@ describe('parse with options', function () {
 
     it('should allow parsing display name with comma', function (done) {
         try {
-            const [r] = address.parse('Foo, Bar <foo@example.com>', null, { allowCommaInDisplayName: true });
+            const [r] = address.parse('Foo, Bar <foo@example.com>', { allowCommaInDisplayName: true });
             assert.equal('foo@example.com', r.address);
             assert.equal('Foo, Bar', r.phrase);
         }

--- a/test/functions.js
+++ b/test/functions.js
@@ -95,7 +95,7 @@ describe('parseReplyTo', function () {
 describe('parse with options', function () {
     it('should not allow parsing display name with comma by default', function (done) {
         try {
-            const r = address.parse('Foo, Bar <foo@example.com>');
+            address.parse('Foo, Bar <foo@example.com>');
         }
         catch (e) {
             assert.equal(e.message, 'No results');


### PR DESCRIPTION
This is a similar PR as I made earlier https://github.com/haraka/node-address-rfc2822/pull/47, but this time it allows `,` in the display name.


The feature was added to the email-addresses library with this PR: https://github.com/jackbearheart/email-addresses/pull/54