### PR TITLE
ci: restore GH workflow for PRs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,6 @@
 name: Integration Tests
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
 


### PR DESCRIPTION
- new PRs from forked repos don't get ci-tests triggered with they create a PR (unless they push after)