### PR TITLE
Release v2.2.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 engines:
   eslint:
     enabled: true
-    channel: "eslint-6"
+    channel: "eslint-8"
     config:
       config: ".eslintrc.yaml"
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,3 +8,8 @@ engines:
 ratings:
    paths:
    - "**.js"
+
+checks:
+  method-complexity:
+    config:
+      threshold: 10

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -15,10 +15,8 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Use Node.js 16
+    - name: Use Node.js
       uses: actions/setup-node@master
-      with:
-        node-version: 16.x
 
     - name: install, run
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".release"]
+	path = .release
+	url = git@github.com:msimerson/.release.git

--- a/Changes.md
+++ b/Changes.md
@@ -4,12 +4,14 @@
 
 ### [2.2.0] - 2024-02-23
 
-- chore: add inline documentation for parse #60
-- test: drop node 10, add node 16 #61
+- feat: option to allow comma in display name #52
 - dep(email-addresses): bump from 4.0.0 to 5.0.0 #58
+- chore: replace a couple regex with slice (perf & sec) #63
+- test: a few more tests to boost coverage #63
+- test: drop node 10, add node 16 #61
 - ci: restore GH workflow for PRs #57
 - ci: add dependabot.yml #55
-- feat: allow comma in display name #52
+- doc: add inline documentation for parse #60
 - doc(Changes): make PR #s into links #54
 - doc(README): add result of console.logs #56
 - doc(README): add links to RFC 2822, 5322 #53

--- a/Changes.md
+++ b/Changes.md
@@ -73,4 +73,5 @@
 ### 1.0.0 - 2016-02-23
 
 - Initial implementation
-[2.1.1]: https://github.com/haraka/node-address-rfc2822/releases/tag/2.1.1
+
+[2.2.0]: https://github.com/haraka/node-address-rfc2822/releases/tag/2.2.0

--- a/Changes.md
+++ b/Changes.md
@@ -1,51 +1,68 @@
 
-## 2.1.0 - 2021-02-26
+### Unreleased
+
+
+### [2.2.0] - 2024-02-23
+
+- chore: add inline documentation for parse #60
+- test: drop node 10, add node 16 #61
+- dep(email-addresses): bump from 4.0.0 to 5.0.0 #58
+- ci: restore GH workflow for PRs #57
+- ci: add dependabot.yml #55
+- feat: allow comma in display name #52
+- doc(Changes): make PR #s into links #54
+- doc(README): add result of console.logs #56
+- doc(README): add links to RFC 2822, 5322 #53
+- doc(README): enabled syntax highlighting with code fences #51
+
+
+### 2.1.0 - 2021-02-26
 
 - make parse accept an options object as second argument
 - allow comma (,) in display name, default off [#52](https://github.com/haraka/node-address-rfc2822/pull/52)
 
 
-## 2.0.6 - 2020-11-17
+### 2.0.6 - 2020-11-17
 
 - replace travis/appveyor CI tests with Github Actions [#48](https://github.com/haraka/node-address-rfc2822/pull/48)
 - test: when splitting lines, use os.EOL
 - allow @ symbol in display name [#47](https://github.com/haraka/node-address-rfc2822/pull/47)
 
 
-## 2.0.5 - 2020-06-02
+### 2.0.5 - 2020-06-02
 
 - update email-addresses to 3.1.0 [#46](https://github.com/haraka/node-address-rfc2822/pull/46)
 - test framework: nodeunit -> mocha
 
 
-## 2.0.4 - 2018-06-29
+### 2.0.4 - 2018-06-29
 
 - throw a proper error object, not a string.
 
 
-## 2.0.3 - 2018-03-01
+### 2.0.3 - 2018-03-01
 
 - use es6 classes
 - export the Address class [#29](https://github.com/haraka/node-address-rfc2822/pull/29)
 
 
-## 2.0.2 - 2018-02-24
+### 2.0.2 - 2018-02-24
 
 - Fix a possible regexp backtracking DoS [#28](https://github.com/haraka/node-address-rfc2822/pull/28)
 
 
-## 2.0.1 - 2017-06-26
+### 2.0.1 - 2017-06-26
 
 - trim the line in parse() [#24](https://github.com/haraka/node-address-rfc2822/pull/24)
 
 
-## 1.0.2 - 2016-06-16
+### 1.0.2 - 2016-06-16
 
 - updated for eslint 4 compat [#23](https://github.com/haraka/node-address-rfc2822/pull/23)
 - use email-addresses for parser [#20](https://github.com/haraka/node-address-rfc2822/pull/20)
 
 
-## 1.0.1 - 2016-09-23
+### 1.0.1 - 2016-09-23
 
 - use native to[lower|upper]Case functions vs regex
 - remove node 0.12 testing
@@ -53,6 +70,7 @@
 - throw error on nothing to parse
 
 
-## 1.0.0 - 2016-02-23
+### 1.0.0 - 2016-02-23
 
 - Initial implementation
+[2.1.1]: https://github.com/haraka/node-address-rfc2822/releases/tag/2.1.1

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Coverage Status][cov-img]][cov-url]
 
 
-address-rfc2822
-==================
+# address-rfc2822
 
 Parser for RFC 2822 & 5322 (Header) format email addresses.
 
@@ -12,13 +11,11 @@ This module parses RFC 2822 headers containing addresses such as From, To, CC, a
 
 It is almost a direct port of the perl module Mail::Address and I'm grateful to the original authors of that module for the clean code and the tests.
 
-Installation
-------------
+## Installation
 
 `npm install address-rfc2822`
 
-Usage
------
+## Usage
 
 ```js
 const addrparser = require('address-rfc2822');
@@ -31,18 +28,15 @@ console.log(`Email name: ${address.name()}`);     // Matt Sergeant
 console.log(`Reformatted: ${address.format()}`);  // Matt Sergeant <helpme+npm@gmail.com>
 console.log(`User part: ${address.user()}`);      // helpme+npm
 console.log(`Host part: ${address.host()}`);      // gmail.com
-
 ```
 
+## More Info
 
-More Info
--------
 - [RFC 2822](https://tools.ietf.org/html/rfc2822)
 - [RFC 5322](https://tools.ietf.org/html/rfc5322)
 
 
-License
--------
+## License
 
 This module is MIT licensed.
 

--- a/index.js
+++ b/index.js
@@ -186,7 +186,6 @@ function _quote_no_esc (str) {
     let match;
     while ((match = /^[\s\S]*?([\s\S])"/.exec(str))) {
         if (match[1] !== '\\') return true;
-
         str = str.substr(match[0].length);
     }
     return false;

--- a/index.js
+++ b/index.js
@@ -227,27 +227,32 @@ function _extract_name (name) {
     // Using encodings, too hard. See Mail::Message::Field::Full.
     if (/=?.*?\?=/.test(name)) return '';
 
-    // trim whitespace
-    name = name.trim();
-    name = name.replace(/\s+/, ' ');
+    // trim & condense whitespace
+    name = name.trim().replace(/\s+/, ' ');
 
     // Disregard numeric names (e.g. 123456.1234@compuserve.com)
     if (/^[\d ]+$/.test(name)) return '';
 
-    name = name.replace(/^\((.*)\)$/, '$1') // remove outermost parenthesis
-        .replace(/^"(.*)"$/, '$1')  // remove outer quotation marks
-        .replace(/\(.*?\)/g, '')    // remove minimal embedded comments
-        .replace(/\\/g, '')         // remove all escapes
-        .replace(/^"(.*)"$/, '$1')  // remove internal quotation marks
-        .replace(/^([^\s]+) ?, ?(.*)$/, '$2 $1') // reverse "Last, First M." if applicable
+    // remove outermost parenthesis
+    if (name.slice(0,1) === '(' && name.slice(-1) === ')') name = name.slice(1,name.length-1)
+
+    // remove outer quotation marks
+    if (name.slice(0,1) === '"' && name.slice(-1) === '"') name = name.slice(1,name.length-1)
+
+    name = name.replace(/\(.*?\)/g, '')    // remove minimal embedded comments
+        .replace(/\\/g, '');         // remove all escapes
+
+    // remove internal quotation marks
+    if (name.slice(0,1) === '"' && name.slice(-1) === '"') name = name.slice(1,name.length-1)
+
+    name = name.replace(/^([^\s]+) ?, ?(.*)$/, '$2 $1') // reverse "Last, First M." if applicable
         .replace(/,.*/, '');
 
     // Change casing only when the name contains only upper or only
     // lower cased characters.
     if ( exports.isAllUpper(name) || exports.isAllLower(name) ) {
-        // console.log("Changing case of: " + name);
+        // console.log(`Changing case: ${name} to ${exports.nameCase(name)}`);
         name = exports.nameCase(name);
-        // console.log("Now: " + name);
     }
 
     // some cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2822",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "RFC 2822 & 5322 (Header) email address parser",
   "main": "index.js",
   "homepage": "https://github.com/haraka/node-address-rfc2822",
@@ -25,9 +25,8 @@
     "url": "https://github.com/haraka/node-address-rfc2822.git"
   },
   "devDependencies": {
-    "eslint": "*",
-    "eslint-plugin-haraka": "*",
-    "mocha": "*"
+    "eslint": "8.56.0",
+    "eslint-plugin-haraka": "1.0.15"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/Address.js
+++ b/test/Address.js
@@ -1,18 +1,26 @@
-const assert  = require('assert')
+const assert  = require('node:assert/strict')
 
 const address = require('../index')
 
 
 describe('Address', function () {
-    it('host', function (done) {
+    it('host', function () {
         const r = new address.Address(null, 'user@example.com');
         assert.equal(r.host(), 'example.com');
-        done();
     })
 
-    it('user', function (done) {
+    it('host, email missing domain', function () {
+        const r = new address.Address(null, 'user');
+        assert.equal(r.host(), null);
+    })
+
+    it('user', function () {
         const r = new address.Address(null, 'user@example.com');
         assert.equal(r.user(), 'user');
-        done();
+    })
+
+    it('host, user missing domain', function () {
+        const r = new address.Address(null, 'user');
+        assert.equal(r.user(), null);
     })
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,5 @@
 
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const fs     = require('fs')
 const path   = require('path')
 
@@ -8,14 +8,23 @@ const parse  = require('../index').parse;
 const raw_data = fs.readFileSync(path.join(__dirname, 'emails.txt'), "UTF-8");
 const EOLRE  = new RegExp(require('os').EOL)
 
-const tests = raw_data.split(/\n\n/).map(function (rows) {
+const tests = raw_data.split(/\n\n/).map((rows) => {
     const lines = rows.split(EOLRE);
     // console.log(lines)
     if (lines[0] === '') lines.shift();
     return lines.filter((l) => { return !/^#/.test(l) });
 });
 
-describe('basic parse', function () {
+describe('parse', function () {
+
+    it('throws on empty line', function () {
+        assert.throws(() => {
+            const parsed = parse('');
+        },
+        {
+            message: 'Nothing to parse'
+        })
+    })
 
     tests.forEach(function (test) {
 
@@ -29,7 +38,7 @@ describe('basic parse', function () {
             // console.log(`Parsed: ${parsed}`);
 
             for (const k in details) {
-                assert.strictEqual(parsed[k](), details[k], `Test '${k}' for '${parsed[k]()}' = '${details[k]}' from ${JSON.stringify(parsed)}`);
+                assert.equal(parsed[k](), details[k], `Test '${k}' for '${parsed[k]()}' = '${details[k]}' from ${JSON.stringify(parsed)}`);
             }
         })
     })

--- a/test/basic.js
+++ b/test/basic.js
@@ -18,12 +18,7 @@ const tests = raw_data.split(/\n\n/).map((rows) => {
 describe('parse', function () {
 
     it('throws on empty line', function () {
-        assert.throws(() => {
-            const parsed = parse('');
-        },
-        {
-            message: 'Nothing to parse'
-        })
+        assert.throws(() => { parse(''); }, { message: 'Nothing to parse' })
     })
 
     tests.forEach(function (test) {

--- a/test/emails.txt
+++ b/test/emails.txt
@@ -190,3 +190,7 @@ Nightly Monitor Robot
 Managing Partners:ben@example.com,carol@example.com;
 Managing Partners:ben@example.com,carol@example.com
 Managing Partners
+
+"Boomer" <123456.1234@compuserve.com>
+Boomer <123456.1234@compuserve.com>
+Boomer


### PR DESCRIPTION
- feat: option to allow comma in display name #52
- dep(email-addresses): bump from 4.0.0 to 5.0.0 #58
- chore: replace a couple regex with slice (perf & sec) #63
- test: a few more tests to boost coverage #63
- test: drop node 10, add node 16 #61
- ci: restore GH workflow for PRs #57
- ci: add dependabot.yml #55
- doc: add inline documentation for parse #60
- doc(Changes): make PR #s into links #54
- doc(README): add result of console.logs #56
- doc(README): add links to RFC 2822, 5322 #53
- doc(README): enabled syntax highlighting with code fences #51